### PR TITLE
removed unused import

### DIFF
--- a/Libs/MMAX2/org/eml/MMAX2/core/MMAX2.java
+++ b/Libs/MMAX2/org/eml/MMAX2/core/MMAX2.java
@@ -808,7 +808,7 @@ public class MMAX2 extends javax.swing.JFrame implements KeyListener ,java.awt.e
             String file = toki.nextToken();
             file = toki.nextToken();
 
-            MMAX2PopupWindow popup = new MMAX2PopupWindow(file);
+            MMAX2PopupWindow popup = new MMAX2PopupWindow(getCurrentDiscourse().getCommonBasedataPath()+file);
             
             int xPos = this.getCurrentTextPane().getCurrentMouseMoveEvent().getX();              
             int yPos = this.getCurrentTextPane().getCurrentMouseMoveEvent().getY();

--- a/Libs/MMAX2/org/eml/MMAX2/gui/windows/MMAX2ProjectWizard.java
+++ b/Libs/MMAX2/org/eml/MMAX2/gui/windows/MMAX2ProjectWizard.java
@@ -54,7 +54,6 @@ import javax.swing.text.SimpleAttributeSet;
 import org.eml.MMAX2.core.MMAX2;
 import org.eml.MMAX2.utils.MMAX2Utils;
 
-import sun.org.mozilla.javascript.internal.JavaScriptException;
 /**
  *
  * @author  mueller


### PR DESCRIPTION
removed unused import as it references library that is not included. this causes the build to break:
e.g.
javac ....

results in:
./org/eml/MMAX2/gui/windows/MMAX2ProjectWizard.java:57: error: package sun.org.mozilla.javascript.internal does not exist
import sun.org.mozilla.javascript.internal.JavaScriptException;
